### PR TITLE
barebox: add devinfo helper

### DIFF
--- a/labgridhelper/barebox.py
+++ b/labgridhelper/barebox.py
@@ -27,3 +27,31 @@ def get_globals(command):
     assert isinstance(command, BareboxDriver)
     out = command.run_check("global")
     return split_to_dict(out, delimiter=":", strip_chars="* ")
+
+def devinfo(command, device):
+    """Returns the devinfo as dict
+    Args:
+        command (BareboxDriver): An instance of the BareboxDriver
+        device (string): device to call devinfo on
+    Returns:
+        dict: parameters
+    """
+    assert isinstance(command, BareboxDriver)
+    stdout = command.run_check("devinfo {}".format(device))
+
+    results = {}
+    state = '\n'.join(stdout)
+    for line in state.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        k, v = line.split(':', 1)
+        v = v.strip()
+        if ' ' in v:
+            v, _ = v.split(' ', 1)
+        if not k or not v:
+            continue
+        v = v.strip()
+        results[k] = v
+
+    return results


### PR DESCRIPTION
Returns parameters of a device via barebox' devinfo command.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>
Signed-off-by: Bastian Krause <bst@pengutronix.de>