### PR TITLE
linux.py: handle systemd version without patch info

### DIFF
--- a/labgridhelper/linux.py
+++ b/labgridhelper/linux.py
@@ -16,7 +16,7 @@ def get_systemd_version(command):
     out = command.run_check("systemctl --version")
     out = out[0]
 
-    parsed = re.search(r'^systemd\s+(?P<version>\d+)\s+', out)
+    parsed = re.search(r'^systemd\s+(?P<version>\d+)', out)
     if not parsed:
         raise ValueError("Systemd version output changed")
     return int(parsed.group("version"))


### PR DESCRIPTION
The get_systemd_version function introduced in

    55d35d5 linux: add get_systemd_version()

correctly handles

    systemd 244 (244.3+)
    +PAM -AUDIT -SELINUX +IMA -APPARMOR -SMACK -SYSVINIT...

but not

    systemd 234
    +PAM -AUDIT -SELINUX +IMA -APPARMOR -SMACK +SYSVINIT....

and the call ends with following exception:

    ValueError: Systemd version output changed

Fix it by allowing version to be followed by newline as well.

Signed-off-by: Adam Trhon <adam.trhon@tbs-biometrics.com>