### PR TITLE
setup: loosen python3 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license='LGPL-2.1',
     use_scm_version=True,
     url='https://github.com/labgrid-project',
-    python_requires='>=3.5, <3.8',
+    python_requires='>=3.5',
     setup_requires=['setuptools_scm'],
     install_requires=[
         'labgrid>=0.1.0',


### PR DESCRIPTION
Instead of limiting to a specific maximum python version, allow all
python3 versions greater than 3.5.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>