### PR TITLE
setup: Loosen dependency version for labgrid

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     python_requires='>=3.5',
     setup_requires=['setuptools_scm'],
     install_requires=[
-        'labgrid>=0.1.0',
+        'labgrid>=0.1.*',
     ],
     packages=[
         'labgridhelper',


### PR DESCRIPTION
When installing labgridhelper it will first search for an installed
labgrid>=0.1.0. This will fail to find working development versions such
as "0.1.dev1+g3eb7807".

This has a knock-on effect of searching for a suitable "labgrid"
dependency in PyPI. Currently this is labgrid==0.1.0, which contains a
Python 3.7.3 syntax error.

The upshot is that installing labgridhelper with a valid labgrid
version ("0.1.dev1+g3eb7807"), breaks labgrid altogether.

Loosen the dependecy so that working labgrid versions are acceptable
depdenencies.

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>

---

You can reproduce this error with the following commands:
```
$ podman run -w /root -it labgrid/client

## a working version of labgrid is present

root@9381df333fac:~# labgrid-client | head
usage: labgrid-client [-h] [-x URL] [-c CONFIG] [-p PLACE] [-s STATE] [-d]
                      [-v] [-P PROXY]
                      COMMAND ...

optional arguments:
  -h, --help            show this help message and exit
  -x URL, --crossbar URL
                        crossbar websocket URL (default:
                        ws://127.0.0.1:20408/ws)
  -c CONFIG, --config CONFIG

## labgridhelper installs a broken version of labgrid

root@877217804f5d:~/labgridhelper# git clone https://github.com/labgrid-project/labgridhelper.git
root@877217804f5d:~/labgridhelper# cd labgridhelper/
root@877217804f5d:~/labgridhelper# python3 setup.py install
root@877217804f5d:~/labgridhelper# labgrid-client 
Traceback (most recent call last):
  File "/usr/local/bin/labgrid-client", line 11, in <module>
    load_entry_point('labgrid==0.1.0', 'console_scripts', 'labgrid-client')()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.7/dist-packages/labgrid-0.1.0-py3.7.egg/labgrid/__init__.py", line 1, in <module>
    from .target import Target
  File "/usr/local/lib/python3.7/dist-packages/labgrid-0.1.0-py3.7.egg/labgrid/target.py", line 68
    def get_resource(self, cls, *, await=True):
                                       ^
SyntaxError: invalid syntax

```