### PR TITLE
linux: fix parsing of old systemd 'type' right after boot

### DIFF
--- a/labgridhelper/linux.py
+++ b/labgridhelper/linux.py
@@ -85,11 +85,10 @@ def get_systemd_status(command):
             services[name]["active"] = next(data)
             services[name]["sub"] = next(data)
             services[name]["follow"] = next(data)
-            path_and_id = next(data)
-            pos = path_and_id.index('"')
-            services[name]["path"] = path_and_id[:pos]
-            services[name]["id"] = int(path_and_id[pos+1:-1].strip(" "))
-            services[name]["type"] = path_and_id[path_and_id.rfind('"'):]
+            path_and_id = next(data).split('\"')
+            services[name]["path"] = path_and_id[0]
+            services[name]["id"] = int(path_and_id[1].strip(" "))
+            services[name]["type"] = path_and_id[2]
             services[name]["objpath"] = next(data)
 
         return services


### PR DESCRIPTION
With old systemd (before 240), just after boot, the
get_systemd_status_raw function fails with the following exception:

ValueError: invalid literal for int() with base 10: '2 "star'

Calling `print(path_and_id)` before parsing prints the following:

    /org/freedesktop/systemd1/unit/syslog_2eservice" 0 "
    /org/freedesktop/systemd1/unit/alsa_2drestore_2eservice" 0 "
    /org/freedesktop/systemd1/unit/dev_2dram0_2edevice" 0 "
    /org/freedesktop/systemd1/unit/multi_2duser_2etarget" 2 "start

The last line causes the error which is fixed by this patch.

Signed-off-by: Adam Trhon <adam.trhon@tbs-biometrics.com>